### PR TITLE
include文をソースコードからの相対パスでインクルード可能になるよう拡張

### DIFF
--- a/VS2013/MokkosuCore/Input/InputStream.cs
+++ b/VS2013/MokkosuCore/Input/InputStream.cs
@@ -37,7 +37,8 @@ namespace Mokkosu.Input
                 return;
             }
 
-            var path = Path.Combine(_exe_path, fname);
+            var root = fname.StartsWith("./") ? Path.GetDirectoryName(_current_srcfile.Name) : _exe_path;
+            var path = Path.Combine(root, Path.GetDirectoryName(fname.Substring(2)), Path.GetFileName(fname));
             if (File.Exists(path))
             {
                 _source_stack.Push(_current_srcfile);

--- a/VS2013/MokkosuCore/Input/InputStream.cs
+++ b/VS2013/MokkosuCore/Input/InputStream.cs
@@ -37,8 +37,11 @@ namespace Mokkosu.Input
                 return;
             }
 
-            var root = fname.StartsWith("./") ? Path.GetDirectoryName(_current_srcfile.Name) : _exe_path;
-            var path = Path.Combine(root, Path.GetDirectoryName(fname.Substring(2)), Path.GetFileName(fname));
+            var root = _exe_path;
+            if (fname.StartsWith("./") || fname.StartsWith("../"))
+                root = Path.GetDirectoryName(_current_srcfile.Name);
+            var path = Path.GetFullPath(string.Format("{0}/{1}", root, fname));
+
             if (File.Exists(path))
             {
                 _source_stack.Push(_current_srcfile);

--- a/VS2013/MokkosuCore/Input/SourceFile.cs
+++ b/VS2013/MokkosuCore/Input/SourceFile.cs
@@ -8,6 +8,8 @@ namespace Mokkosu.Input
         int _line;
         TextReader _tr;
 
+        public string Name { get { return _name; } }
+
         public SourceFile(TextReader tr, string name)
         {
             _name = name;


### PR DESCRIPTION
"./"、"../"から始まる場合にソースコードからの相対パスとして認識するよう拡張してみました。
path_to/test.mokに`include "./lib.mok"`とあった場合、path_to/lib.mokをインクルードします。
相対パス指定でない場合(`include "List.mok"`のような場合)は今までどおりMokkosu.exeのパスから探します。
