### PR TITLE
MokkosuPad起動時のパラメータをファイルの絶対パスとして認識するよう変更

### DIFF
--- a/VS2013/MokkosuPad/Models/Model.cs
+++ b/VS2013/MokkosuPad/Models/Model.cs
@@ -131,19 +131,18 @@ namespace MokkosuPad.Models
         {
             using (var strm = new StreamReader(path))
             {
-                var str = strm.ReadToEnd();
-                return str;
-            }
+                return strm.ReadToEnd();
+           }
         }
 
-        public static string GetSampleProgramString()
+        public static string GetSampleOrFileString()
         {
-            var name = Environment.GetCommandLineArgs().Skip(1).SingleOrDefault();
+            var name = Environment.GetCommandLineArgs().Skip(1).FirstOrDefault();
             if (name != null)
             {
                 return GetProgramString(name);
             }
-            
+
             var exe_path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
             return GetProgramString(Path.Combine(exe_path, "Startup.mok"));
         }

--- a/VS2013/MokkosuPad/Models/Model.cs
+++ b/VS2013/MokkosuPad/Models/Model.cs
@@ -127,14 +127,25 @@ namespace MokkosuPad.Models
             return _mokkosu.GetVersionString();
         }
 
-        public static string GetSampleProgramString()
+        static string GetProgramString(string path)
         {
-            var exe_path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
-            using (var strm = new StreamReader(Path.Combine(exe_path, "Startup.mok")))
+            using (var strm = new StreamReader(path))
             {
                 var str = strm.ReadToEnd();
                 return str;
             }
+        }
+
+        public static string GetSampleProgramString()
+        {
+            var name = Environment.GetCommandLineArgs().Skip(1).SingleOrDefault();
+            if (name != null)
+            {
+                return GetProgramString(name);
+            }
+            
+            var exe_path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            return GetProgramString(Path.Combine(exe_path, "Startup.mok"));
         }
     }
 }

--- a/VS2013/MokkosuPad/ViewModels/MainWindowViewModel.cs
+++ b/VS2013/MokkosuPad/ViewModels/MainWindowViewModel.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Xml;
 using System.Windows.Threading;
 using System.Threading;
+using System.Linq;
 
 namespace MokkosuPad.ViewModels
 {
@@ -31,6 +32,13 @@ namespace MokkosuPad.ViewModels
 
             Documents.Add(_source_vm);
             Documents.Add(_output_vm);
+
+            var name = Environment.GetCommandLineArgs().Skip(1).FirstOrDefault();
+            if (name != null)
+            {
+                _source_fname = name;
+                WindowTitle = ProgramName + " - " + Path.GetFileName(_source_fname);
+            }
 
             Model.OutputReceived += OutputReceived;
         }

--- a/VS2013/MokkosuPad/ViewModels/SourceViewModel.cs
+++ b/VS2013/MokkosuPad/ViewModels/SourceViewModel.cs
@@ -79,7 +79,7 @@ namespace MokkosuPad.ViewModels
         {
             if (!loaded_flg)
             {
-                Text = Model.GetSampleProgramString();
+                Text = Model.GetSampleOrFileString();
                 DirtyFlag = false;
                 loaded_flg = true;
             }


### PR DESCRIPTION
MokkosuPad.exeへファイルをD&Dしたり*.mokにMokkosuPadを関連付けている場合、該当ファイルをMokkosuPadで開くよう変更しました。
起動パラメータがない場合は今までどおりStartup.mokを開きます。
